### PR TITLE
Bump version to 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-08-28
+
 ### Added
 
 - `dissolve` (API and CLI) gains `exclude` and `target_schema` options
@@ -354,7 +356,8 @@ Initial release: four tools, CLI + Python API for each.
   unit as unchanged/renamed/modified/relocated/split/merge/complex/created/
   removed, via spatial overlap and optional code/name identity linking.
 
-[Unreleased]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.4...HEAD
+[0.5.4]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.0...v0.5.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "topo-tools"
-version = "0.5.3"
+version = "0.5.4"
 description = "DuckDB-powered geospatial topology utilities (edge-matching, topology cleaning, more)"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -538,7 +538,7 @@ wheels = [
 
 [[package]]
 name = "topo-tools"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bumps version to 0.5.4 and moves the CHANGELOG `[Unreleased]` entries (dissolve `exclude`/`target_schema`) under `## [0.5.4]`