### PR TITLE
Decouple Homebrew tap bump from release-triggered publish

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -1,0 +1,39 @@
+name: Update Homebrew tap
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+jobs:
+  update-homebrew-tap:
+    runs-on: macos-latest
+    steps:
+      - name: Latest PyPI version
+        id: pypi
+        run: |
+          version=$(curl -s https://pypi.org/pypi/topo-tools/json | jq -r .info.version)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Tap OCHA-DAP/homebrew-topo-tools
+        run: brew tap OCHA-DAP/topo-tools
+
+      - name: Current tap version
+        id: tap
+        run: |
+          version=$(brew info --json=v2 OCHA-DAP/topo-tools/topo-tools | jq -r '.formulae[0].versions.stable')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Open Homebrew formula bump PR
+        if: steps.pypi.outputs.version != steps.tap.outputs.version
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+        run: |
+          brew bump-formula-pr \
+            --no-fork \
+            --no-browse \
+            --install-dependencies \
+            --version="${{ steps.pypi.outputs.version }}" \
+            OCHA-DAP/topo-tools/topo-tools

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,29 +28,3 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
-
-  update-homebrew-tap:
-    needs: publish
-    runs-on: macos-latest
-    steps:
-      - name: Derive released version
-        id: version
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Tap OCHA-DAP/homebrew-topo-tools
-        run: brew tap OCHA-DAP/topo-tools
-
-      - name: Open Homebrew formula bump PR
-        env:
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          HOMEBREW_NO_AUTO_UPDATE: "1"
-          HOMEBREW_NO_INSTALL_CLEANUP: "1"
-        run: |
-          brew bump-formula-pr \
-            --no-fork \
-            --no-browse \
-            --install-dependencies \
-            --version="${{ steps.version.outputs.version }}" \
-            OCHA-DAP/topo-tools/topo-tools

--- a/docs/how-to/publishing.md
+++ b/docs/how-to/publishing.md
@@ -6,7 +6,7 @@
 - Pending trusted publisher registered at <https://pypi.org/manage/account/publishing/>: project `topo-tools`, owner `OCHA-DAP`, repo `topo-tools-py`, workflow `publish.yml`, environment `pypi`. This authorizes GitHub Actions to publish via OIDC, no long-lived API token stored anywhere.
 - **Repo moved from `fieldmaps` to `OCHA-DAP`.** If the PyPI trusted publisher still shows owner `fieldmaps`, update it at the link above before the next release; GitHub's OIDC token now asserts `OCHA-DAP` as the repo owner and the publish job's OIDC exchange will fail on a mismatch.
 - `.github/workflows/publish.yml` triggers only on `release: published`, never on push/tag alone.
-- `HOMEBREW_TAP_TOKEN` repository secret: a fine-grained PAT scoped to `OCHA-DAP/homebrew-topo-tools` (`Contents: Read and write`, `Pull requests: Read and write`), used by the `update-homebrew-tap` job to open formula-bump PRs. Expires 2027-08-27; renew it before then or that job starts failing.
+- `HOMEBREW_TAP_TOKEN` repository secret: a fine-grained PAT scoped to `OCHA-DAP/homebrew-topo-tools` (`Contents: Read and write`, `Pull requests: Read and write`), used by `.github/workflows/homebrew-tap.yml` to open formula-bump PRs. Expires 2027-08-27; renew it before then or that job starts failing.
 
 None of the above needs to be redone for future releases. It's specific to real PyPI; TestPyPI (below) is a fully separate service with its own account/tokens and isn't wired into this workflow.
 
@@ -17,6 +17,7 @@ None of the above needs to be redone for future releases. It's specific to real 
 3. Merge to `main` (release-triggered workflows run from the default branch).
 4. GitHub → Releases → Draft a new release → tag it (e.g. `v0.1.1`) → Publish release.
 5. Approve the `publish` job in the Actions run (the required-reviewer gate from the environment setup above).
+6. `.github/workflows/homebrew-tap.yml` picks up the new version on its next daily run and opens a formula-bump PR against `OCHA-DAP/homebrew-topo-tools` if the tap is behind; review and merge it there. No manual step needed here, but `brew bump-formula-pr --install-dependencies` requires the PyPI upload to be more than 24h old, so a same-day `workflow_dispatch` re-run can still fail.
 
 Version numbers, once uploaded, are permanent: PyPI never allows re-uploading the same filename again, even after deletion. Staying in `0.x` (SemVer's "no compatibility promises yet" range) means there's no expectation of a steady cadence or of never breaking the CLI/API between releases.
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -59,10 +59,11 @@ install OCHA-DAP/topo-tools/topo-tools` (Homebrew ≥6.0.0's tap trust
 auto-trusts a fully-qualified install, no separate `brew tap`/`brew trust`
 step needed).
 
-Version bumps are automated: `.github/workflows/publish.yml`'s
-`update-homebrew-tap` job runs `brew bump-formula-pr` after each PyPI
-publish, opening a PR against the tap with the new `url`/`sha256` and
-regenerated resource blocks (review and merge like any other PR, nothing
+Version bumps are automated: `.github/workflows/homebrew-tap.yml` runs
+daily, comparing the tap's current formula version against PyPI's latest
+`topo-tools` release, and runs `brew bump-formula-pr` to open a PR
+against the tap with the new `url`/`sha256` and regenerated resource
+blocks whenever they differ (review and merge like any other PR, nothing
 merges unattended). That job needs a `HOMEBREW_TAP_TOKEN` repository secret
 (a fine-grained PAT scoped to `OCHA-DAP/homebrew-topo-tools` with
 `Contents: Read and write` and `Pull requests: Read and write`), set up


### PR DESCRIPTION
## Summary
- `brew bump-formula-pr --install-dependencies` resolves via `pip install --dry-run --uploaded-prior-to=P1D`, a fixed 24h-old constraint on the PyPI upload it's bumping to. Running it in the same workflow run as `publish` (as `update-homebrew-tap` did) is structurally guaranteed to fail, confirmed live on the v0.5.4 release: `publish` succeeded, the Homebrew job failed, no PR opened on `OCHA-DAP/homebrew-topo-tools`.
- Removes `update-homebrew-tap` from `publish.yml`; adds `.github/workflows/homebrew-tap.yml` on a daily `schedule` (+ `workflow_dispatch`) that diffs the tap's current formula version against PyPI's latest and only bumps when they differ.
- Updates `docs/how-to/publishing.md` and `packaging/README.md` to describe the new decoupled flow.

## Test plan
- [x] Both workflow YAML files parse cleanly (`yaml.safe_load`, pre-commit's `check-yaml`)
- [ ] After merge, manually trigger `homebrew-tap.yml` (`gh workflow run homebrew-tap.yml`) and confirm it opens a bump PR for the still-outstanding 0.5.3 -> 0.5.4 tap gap