### PR TITLE
Document branch-per-issue workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,13 @@ three-layer split (`core/` → `api/` → `cli/`) and the rule that `core/` and
 `api/` must never import `click`. New tools should follow the same
 `core/api/cli` layering as `edge-extend`.
 
+## Workflow
+
+Work on an issue starts on its own branch off `main`, before any
+exploration or research, not just before the first commit. Open a PR
+referencing the issue once the checklist below is met; `main` is
+protected and only accepts merges via PR.
+
 ## What a finished PR looks like
 
 - [ ] Tests added/updated for the change


### PR DESCRIPTION
## Summary
- \`main\` now has a repository ruleset requiring PRs (squash-only, linear history, \`lint\` status check), no direct pushes.
- \`CONTRIBUTING.md\` states work on an issue starts on its own branch before any exploration, not just before the first commit.

## Test plan
- [x] \`CONTRIBUTING.md\` renders correctly