### PR TITLE
Require tutorial coverage for new public API/CLI options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,8 @@ protected and only accepts merges via PR.
 - [ ] `uv run pytest` passes
 - [ ] `uv run ruff format && uv run ruff check` clean
 - [ ] Docs updated (README, `CLAUDE.md`, or `docs/*.md`) if user-facing
-      behavior changed
+      behavior changed; a new public API/CLI option gets an example in
+      `docs/tutorials/{tool}.md`
 - [ ] `CHANGELOG.md` updated under `## [Unreleased]` for user-visible
       changes
 


### PR DESCRIPTION
## Summary
- \`CONTRIBUTING.md\`'s "finished PR" checklist now says a new public API/CLI option needs a \`docs/tutorials/{tool}.md\` example, not just a general docs mention.
- Prompted by #22, which added \`--cascade-from-level\` to \`schema-fill\` and initially shipped without a tutorial example.

## Test plan
- [x] \`CONTRIBUTING.md\` renders correctly