### PR TITLE
Bump version to 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.5] - 2026-08-31
+
 ### Added
 
 - `edge-stitch`, `edge-match`, and `edge-mosaic` (API and CLI) gain an
@@ -378,7 +380,8 @@ Initial release: four tools, CLI + Python API for each.
   unit as unchanged/renamed/modified/relocated/split/merge/complex/created/
   removed, via spatial overlap and optional code/name identity linking.
 
-[Unreleased]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.4...HEAD
+[Unreleased]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.5...HEAD
+[0.5.5]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.1...v0.5.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "topo-tools"
-version = "0.5.4"
+version = "0.5.5"
 description = "DuckDB-powered geospatial topology utilities (edge-matching, topology cleaning, more)"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "topo-tools"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` version 0.5.4 -> 0.5.5.
- Move CHANGELOG `[Unreleased]` entries (per-row depth pin, deterministic
  multi-file column order, opt-in `--fill-schema` composition) under `[0.5.5]`.

## Test plan
- [ ] CI green