### PR TITLE
Bump version to 0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.6] - 2026-09-01
+
+### Fixed
+
+- `edge-extend` no longer produces coordinates outside valid WGS84 range
+  for a file with a peripheral boundary point far from the rest of its
+  point cloud (e.g. a remote exclave or polar-adjacent territory): its
+  Voronoi step now clips such a cell to `-180/-90/180/90` when its own
+  bbox exceeds it.
+
 ## [0.5.5] - 2026-08-31
 
 ### Added
@@ -380,7 +390,8 @@ Initial release: four tools, CLI + Python API for each.
   unit as unchanged/renamed/modified/relocated/split/merge/complex/created/
   removed, via spatial overlap and optional code/name identity linking.
 
-[Unreleased]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.5...HEAD
+[Unreleased]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.6...HEAD
+[0.5.6]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.5...v0.5.6
 [0.5.5]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/OCHA-DAP/topo-tools-py/compare/v0.5.2...v0.5.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "topo-tools"
-version = "0.5.5"
+version = "0.5.6"
 description = "DuckDB-powered geospatial topology utilities (edge-matching, topology cleaning, more)"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -560,7 +560,7 @@ wheels = [
 
 [[package]]
 name = "topo-tools"
-version = "0.5.5"
+version = "0.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` version 0.5.5 -> 0.5.6.
- Move CHANGELOG `[Unreleased]` (empty) aside and add a `[0.5.6]` entry for #28's edge-extend Voronoi world-bounds clip fix.

## Test plan
- [x] CI green