### PR TITLE
Auto-merge the homebrew-tap version bump PR

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -37,3 +37,12 @@ jobs:
             --install-dependencies \
             --version="${{ steps.pypi.outputs.version }}" \
             OCHA-DAP/topo-tools/topo-tools
+
+      - name: Merge Homebrew formula bump PR
+        if: steps.pypi.outputs.version != steps.tap.outputs.version
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          gh pr merge --squash --delete-branch \
+            --repo OCHA-DAP/homebrew-topo-tools \
+            "bump-topo-tools-${{ steps.pypi.outputs.version }}"


### PR DESCRIPTION
## Summary
- The homebrew-tap workflow opens a version-bump PR on the tap but never merges it, leaving a manual step that's easy to forget.
- The tap repo has no branch protection or CI to gate on, so the workflow now squash-merges the PR itself right after opening it.

## Test plan
- [ ] Next scheduled/dispatched run of `homebrew-tap.yml` opens and merges a bump PR without manual intervention.